### PR TITLE
argon2id vault encryption with password & biometric root-of-trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ stay on the device, encrypted. No sign-up, no sync server, no analytics.
 
 - **It minds its own business.** No account, no telemetry, no Google Play
   Services on your device.
-- **Encrypted by default.** The local vault is stored in an SQLCipher database;
-  unlock with biometrics (with a password fallback) or a password alone.
+- **Encrypted by default.** The local vault is stored in an SQLCipher database,
+  with your password run through Argon2id before it ever touches the key. Unlock
+  it with a password, biometrics, or both; each method unlocks the same vault
+  independently, so losing one does not lock you out of the others.
 - **Hide on demand.** Optional screenshot protection keeps codes out of the
   recents preview and blocks screen capture.
 - **Standards based.** TOTP and HOTP per [RFC 6238][totp-rfc] and
@@ -31,8 +33,8 @@ stay on the device, encrypted. No sign-up, no sync server, no analytics.
 - **Move between phones without a server.** Encrypted device-to-device sync
   over QR codes, the local Wi-Fi network, or Wi-Fi Direct. The handshake is
   end-to-end encrypted and nothing leaves the local network.
-- **Bring it with you.** Encrypted backup and restore for migrating or just
-  feeling safer.
+- **Bring it with you.** Encrypted backup and restore (also Argon2id based) for
+  migrating or just feeling safer. Backups from older versions still restore.
 - **Organize the vault.** Group accounts (multiple groups per account if you
   like) and sort the list the way you want.
 - **Pleasant to look at.** Material 3, built with Jetpack Compose.

--- a/app/src/main/java/me/diamondforge/tokn/MainActivity.kt
+++ b/app/src/main/java/me/diamondforge/tokn/MainActivity.kt
@@ -17,6 +17,8 @@ import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -93,6 +95,14 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        lifecycleScope.launch {
+            combine(userPreferencesRepository.biometricEnabled, vaultSession.state) { enabled, state ->
+                enabled && state == VaultState.UNLOCKED
+            }.distinctUntilChanged().collect { ready ->
+                if (ready) enrollBiometricIfNeeded()
+            }
+        }
+
         setContent {
             val themeMode by userPreferencesRepository.themeMode.collectAsStateWithLifecycle(
                 ThemeMode.SYSTEM
@@ -141,7 +151,6 @@ class MainActivity : AppCompatActivity() {
                             if (vaultManager.unlockWithPassword(password)) {
                                 withContext(Dispatchers.Main) {
                                     lockManager.unlock()
-                                    enrollBiometricIfNeeded()
                                 }
                                 true
                             } else {
@@ -293,6 +302,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun enrollBiometricIfNeeded() {
         lifecycleScope.launch {
+            if (!userPreferencesRepository.encryptionEnabled.first()) return@launch
             if (!userPreferencesRepository.biometricEnabled.first()) return@launch
             if (!vaultSession.isUnlocked) return@launch
             val alreadyProvisioned = withContext(Dispatchers.IO) { vaultManager.canBiometricUnlock() }
@@ -314,7 +324,9 @@ class MainActivity : AppCompatActivity() {
                         runCatching { vaultManager.enableBiometric(authenticatedCipher) }
                     }
                 },
-                onError = { _, _ -> },
+                onError = { _, _ ->
+                    lifecycleScope.launch { userPreferencesRepository.setBiometricEnabled(false) }
+                },
                 onFailed = { },
             )
         }

--- a/app/src/main/java/me/diamondforge/tokn/MainActivity.kt
+++ b/app/src/main/java/me/diamondforge/tokn/MainActivity.kt
@@ -21,7 +21,9 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
 import me.diamondforge.tokn.data.preferences.ThemeMode
 import me.diamondforge.tokn.data.preferences.UserPreferencesRepository
 import me.diamondforge.tokn.domain.usecase.GetAccountsUseCase
@@ -96,8 +98,13 @@ class MainActivity : AppCompatActivity() {
         }
 
         lifecycleScope.launch {
-            combine(userPreferencesRepository.biometricEnabled, vaultSession.state) { enabled, state ->
-                enabled && state == VaultState.UNLOCKED
+            combine(
+                userPreferencesRepository.onboardingDone,
+                userPreferencesRepository.encryptionEnabled,
+                userPreferencesRepository.biometricEnabled,
+                vaultSession.state,
+            ) { done, encryption, biometric, state ->
+                done && encryption && biometric && state == VaultState.UNLOCKED
             }.distinctUntilChanged().collect { ready ->
                 if (ready) enrollBiometricIfNeeded()
             }
@@ -160,6 +167,7 @@ class MainActivity : AppCompatActivity() {
                     },
                     hasVaultPassword = hasVaultPassword,
                     biometricEnabled = biometricEnabled,
+                    onSetupBiometric = { setupBiometric() },
                 )
 
                 if (isLocked == false && onboardingDone == true && upgradeDue && !upgradeDismissed) {
@@ -296,6 +304,35 @@ class MainActivity : AppCompatActivity() {
                 }
             },
             onError = { _, _ -> },
+            onFailed = { },
+        )
+    }
+
+    private suspend fun setupBiometric(): Boolean = suspendCancellableCoroutine { cont ->
+        if (!biometricHelper.isBiometricEnrolled()) {
+            if (cont.isActive) cont.resume(false)
+            return@suspendCancellableCoroutine
+        }
+        val cipher = runCatching { vaultManager.biometricEncryptCipher() }.getOrNull()
+        if (cipher == null) {
+            if (cont.isActive) cont.resume(false)
+            return@suspendCancellableCoroutine
+        }
+        biometricHelper.authenticateForCrypto(
+            activity = this,
+            title = getString(R.string.biometric_prompt_title),
+            subtitle = getString(R.string.biometric_prompt_subtitle),
+            negativeButton = getString(android.R.string.cancel),
+            cryptoObject = BiometricPrompt.CryptoObject(cipher),
+            onSuccess = { authenticatedCipher ->
+                lifecycleScope.launch {
+                    withContext(Dispatchers.IO) {
+                        runCatching { vaultManager.enableBiometric(authenticatedCipher) }
+                    }
+                    if (cont.isActive) cont.resume(true)
+                }
+            },
+            onError = { _, _ -> if (cont.isActive) cont.resume(false) },
             onFailed = { },
         )
     }

--- a/app/src/main/java/me/diamondforge/tokn/MainActivity.kt
+++ b/app/src/main/java/me/diamondforge/tokn/MainActivity.kt
@@ -186,6 +186,7 @@ class MainActivity : AppCompatActivity() {
             val timeout = userPreferencesRepository.autoLockTimeoutSeconds.first()
             lockManager.onAppForeground(timeout)
             if (!vaultSession.isUnlocked || lockManager.isLocked.value != false) {
+                vaultSession.lock()
                 requestBiometric()
             }
         }

--- a/app/src/main/java/me/diamondforge/tokn/MainActivity.kt
+++ b/app/src/main/java/me/diamondforge/tokn/MainActivity.kt
@@ -5,10 +5,15 @@ import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.biometric.BiometricPrompt
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,7 +26,10 @@ import me.diamondforge.tokn.domain.usecase.GetAccountsUseCase
 import me.diamondforge.tokn.navigation.AppNavHost
 import me.diamondforge.tokn.security.BiometricHelper
 import me.diamondforge.tokn.security.LockManager
-import me.diamondforge.tokn.security.VaultPasswordManager
+import me.diamondforge.tokn.security.vault.VaultManager
+import me.diamondforge.tokn.security.vault.VaultSession
+import me.diamondforge.tokn.security.vault.VaultState
+import me.diamondforge.tokn.ui.RootOfTrustUpgradeDialog
 import me.diamondforge.tokn.ui.theme.SimpleOTPTheme
 import javax.inject.Inject
 
@@ -30,14 +38,23 @@ class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var lockManager: LockManager
+
     @Inject
     lateinit var biometricHelper: BiometricHelper
+
     @Inject
     lateinit var userPreferencesRepository: UserPreferencesRepository
+
     @Inject
-    lateinit var vaultPasswordManager: VaultPasswordManager
+    lateinit var vaultManager: VaultManager
+
     @Inject
-    lateinit var getAccountsUseCase: GetAccountsUseCase
+    lateinit var vaultSession: VaultSession
+
+    // Lazy: eager injection would open the encrypted DB during onCreate, before
+    // the vault is unlocked.
+    @Inject
+    lateinit var getAccountsUseCase: Lazy<GetAccountsUseCase>
 
     // Set to true once the pre-OOBE migration check has run.
     // The UI must not render the onboarding flow before this is true; otherwise
@@ -45,13 +62,35 @@ class MainActivity : AppCompatActivity() {
     // bounced to the home screen.
     private val migrationComplete = MutableStateFlow(false)
 
+    private val upgradeNeeded = MutableStateFlow(false)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         enableEdgeToEdge()
         lifecycleScope.launch {
+            // Migrate to the slot-based vault and, when no password/biometric is
+            // configured, transparently unlock from the no-auth keystore slot so
+            // the database can be opened. Never generates a new master key when an
+            // old passphrase exists, so existing data always stays accessible.
+            withContext(Dispatchers.IO) {
+                vaultManager.initIfNeeded()
+                if (!vaultManager.requiresUnlock()) {
+                    vaultManager.tryAutoUnlock()
+                }
+            }
             migrateOnboardingFlag()
             migrationComplete.value = true
+        }
+
+        lifecycleScope.launch {
+            vaultSession.state.collect { state ->
+                upgradeNeeded.value = if (state == VaultState.UNLOCKED) {
+                    withContext(Dispatchers.IO) { vaultManager.needsRootOfTrustUpgrade() }
+                } else {
+                    false
+                }
+            }
         }
 
         setContent {
@@ -87,7 +126,10 @@ class MainActivity : AppCompatActivity() {
                 }
             }
 
-            val hasVaultPassword = encryptionEnabled && vaultPasswordManager.hasPassword()
+            val hasVaultPassword = encryptionEnabled && vaultManager.hasPasswordOrLegacy()
+
+            val upgradeDue by upgradeNeeded.collectAsStateWithLifecycle()
+            var upgradeDismissed by rememberSaveable { mutableStateOf(false) }
 
             SimpleOTPTheme(themeMode = themeMode, dynamicColor = dynamicColorEnabled) {
                 AppNavHost(
@@ -96,8 +138,11 @@ class MainActivity : AppCompatActivity() {
                     onUnlock = { requestBiometric() },
                     onUnlockWithPassword = { password ->
                         withContext(Dispatchers.IO) {
-                            if (vaultPasswordManager.verify(password)) {
-                                withContext(Dispatchers.Main) { lockManager.unlock() }
+                            if (vaultManager.unlockWithPassword(password)) {
+                                withContext(Dispatchers.Main) {
+                                    lockManager.unlock()
+                                    enrollBiometricIfNeeded()
+                                }
                                 true
                             } else {
                                 false
@@ -107,6 +152,17 @@ class MainActivity : AppCompatActivity() {
                     hasVaultPassword = hasVaultPassword,
                     biometricEnabled = biometricEnabled,
                 )
+
+                if (isLocked == false && onboardingDone == true && upgradeDue && !upgradeDismissed) {
+                    RootOfTrustUpgradeDialog(
+                        onConfirm = { password ->
+                            withContext(Dispatchers.IO) {
+                                vaultManager.unlockWithPassword(password)
+                            }.also { ok -> if (ok) upgradeNeeded.value = false }
+                        },
+                        onDismiss = { upgradeDismissed = true },
+                    )
+                }
             }
         }
     }
@@ -114,19 +170,22 @@ class MainActivity : AppCompatActivity() {
     override fun onStart() {
         super.onStart()
         lifecycleScope.launch {
+            withContext(Dispatchers.IO) { vaultManager.initIfNeeded() }
             val onboardingDone = userPreferencesRepository.onboardingDone.first()
             if (!onboardingDone) {
+                withContext(Dispatchers.IO) { vaultManager.tryAutoUnlock() }
                 lockManager.unlock()
                 return@launch
             }
             val encryptionEnabled = userPreferencesRepository.encryptionEnabled.first()
             if (!encryptionEnabled) {
+                withContext(Dispatchers.IO) { vaultManager.tryAutoUnlock() }
                 lockManager.unlock()
                 return@launch
             }
             val timeout = userPreferencesRepository.autoLockTimeoutSeconds.first()
             lockManager.onAppForeground(timeout)
-            if (lockManager.isLocked.value != false) {
+            if (!vaultSession.isUnlocked || lockManager.isLocked.value != false) {
                 requestBiometric()
             }
         }
@@ -143,8 +202,8 @@ class MainActivity : AppCompatActivity() {
     private suspend fun migrateOnboardingFlag() {
         if (userPreferencesRepository.onboardingDone.first()) return
         val hasExistingData = withContext(Dispatchers.IO) {
-            vaultPasswordManager.hasPassword() ||
-                    getAccountsUseCase().first().isNotEmpty()
+            vaultManager.hasPasswordOrLegacy() ||
+                    (vaultSession.isUnlocked && getAccountsUseCase.get()().first().isNotEmpty())
         }
         if (hasExistingData) {
             userPreferencesRepository.setOnboardingDone(true)
@@ -158,12 +217,102 @@ class MainActivity : AppCompatActivity() {
                 lockManager.lock()
                 return@launch
             }
+            val canUnlock = withContext(Dispatchers.IO) { vaultManager.canBiometricUnlock() }
+            if (canUnlock) {
+                unlockWithBiometric()
+                return@launch
+            }
+            // Migrated biometric users without a slot yet: provision and unlock
+            // from one fingerprint prompt, no password needed.
+            val canProvision = withContext(Dispatchers.IO) {
+                vaultManager.canProvisionBiometricFromKeystore()
+            }
+            if (canProvision && biometricHelper.isBiometricEnrolled()) {
+                provisionBiometricAndUnlock()
+                return@launch
+            }
             lockManager.lock()
-            biometricHelper.authenticate(
+        }
+    }
+
+    private suspend fun unlockWithBiometric() {
+        lockManager.lock()
+        val cipher = withContext(Dispatchers.IO) { vaultManager.biometricDecryptCipher() }
+        if (cipher == null) {
+            // Biometric key invalidated (e.g. new fingerprint) — fall back to password.
+            return
+        }
+        biometricHelper.authenticateForCrypto(
+            activity = this@MainActivity,
+            title = getString(R.string.biometric_prompt_title),
+            subtitle = getString(R.string.biometric_prompt_subtitle),
+            negativeButton = getString(android.R.string.cancel),
+            cryptoObject = BiometricPrompt.CryptoObject(cipher),
+            onSuccess = { authenticatedCipher ->
+                lifecycleScope.launch {
+                    val ok = withContext(Dispatchers.IO) {
+                        vaultManager.finishBiometricUnlock(authenticatedCipher)
+                    }
+                    if (ok) lockManager.unlock()
+                }
+            },
+            onError = { _, _ -> },
+            onFailed = { },
+        )
+    }
+
+    private suspend fun provisionBiometricAndUnlock() {
+        lockManager.lock()
+        val cipher = withContext(Dispatchers.IO) {
+            runCatching { vaultManager.biometricEncryptCipher() }.getOrNull()
+        }
+        if (cipher == null) {
+            return
+        }
+        biometricHelper.authenticateForCrypto(
+            activity = this@MainActivity,
+            title = getString(R.string.biometric_prompt_title),
+            subtitle = getString(R.string.biometric_prompt_subtitle),
+            negativeButton = getString(android.R.string.cancel),
+            cryptoObject = BiometricPrompt.CryptoObject(cipher),
+            onSuccess = { authenticatedCipher ->
+                lifecycleScope.launch {
+                    val ok = withContext(Dispatchers.IO) {
+                        runCatching {
+                            vaultManager.provisionAndUnlockBiometric(authenticatedCipher)
+                        }.getOrDefault(false)
+                    }
+                    if (ok) lockManager.unlock()
+                }
+            },
+            onError = { _, _ -> },
+            onFailed = { },
+        )
+    }
+
+    private fun enrollBiometricIfNeeded() {
+        lifecycleScope.launch {
+            if (!userPreferencesRepository.biometricEnabled.first()) return@launch
+            if (!vaultSession.isUnlocked) return@launch
+            val alreadyProvisioned = withContext(Dispatchers.IO) { vaultManager.canBiometricUnlock() }
+            if (alreadyProvisioned) return@launch
+            if (!biometricHelper.isBiometricEnrolled()) return@launch
+
+            val cipher = withContext(Dispatchers.IO) {
+                runCatching { vaultManager.biometricEncryptCipher() }.getOrNull()
+            } ?: return@launch
+
+            biometricHelper.authenticateForCrypto(
                 activity = this@MainActivity,
                 title = getString(R.string.biometric_prompt_title),
                 subtitle = getString(R.string.biometric_prompt_subtitle),
-                onSuccess = { lockManager.unlock() },
+                negativeButton = getString(android.R.string.cancel),
+                cryptoObject = BiometricPrompt.CryptoObject(cipher),
+                onSuccess = { authenticatedCipher ->
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        runCatching { vaultManager.enableBiometric(authenticatedCipher) }
+                    }
+                },
                 onError = { _, _ -> },
                 onFailed = { },
             )

--- a/app/src/main/java/me/diamondforge/tokn/navigation/AppNavHost.kt
+++ b/app/src/main/java/me/diamondforge/tokn/navigation/AppNavHost.kt
@@ -91,10 +91,11 @@ fun AppNavHost(
     onUnlockWithPassword: suspend (String) -> Boolean,
     hasVaultPassword: Boolean,
     biometricEnabled: Boolean,
+    onSetupBiometric: suspend () -> Boolean,
 ) {
     if (onboardingDone == null || isLocked == null) return
     if (!onboardingDone) {
-        OnboardingScreen(onFinished = {})
+        OnboardingScreen(onFinished = {}, onSetupBiometric = onSetupBiometric)
         return
     }
     if (isLocked) {

--- a/app/src/main/java/me/diamondforge/tokn/ui/RootOfTrustUpgradeDialog.kt
+++ b/app/src/main/java/me/diamondforge/tokn/ui/RootOfTrustUpgradeDialog.kt
@@ -1,0 +1,108 @@
+package me.diamondforge.tokn.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import me.diamondforge.tokn.R
+
+@Composable
+fun RootOfTrustUpgradeDialog(
+    onConfirm: suspend (String) -> Boolean,
+    onDismiss: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    var password by rememberSaveable { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+    var wrongPassword by remember { mutableStateOf(false) }
+    var isVerifying by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Lock, contentDescription = null) },
+        title = { Text(stringResource(R.string.rot_upgrade_title)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.rot_upgrade_body))
+                Spacer(Modifier.height(16.dp))
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = {
+                        password = it
+                        wrongPassword = false
+                    },
+                    label = { Text(stringResource(R.string.password)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = wrongPassword,
+                    supportingText = if (wrongPassword) {
+                        { Text(stringResource(R.string.wrong_password)) }
+                    } else null,
+                    visualTransformation = if (passwordVisible) {
+                        VisualTransformation.None
+                    } else {
+                        PasswordVisualTransformation()
+                    },
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                if (passwordVisible) {
+                                    Icons.Default.VisibilityOff
+                                } else {
+                                    Icons.Default.Visibility
+                                },
+                                contentDescription = null,
+                            )
+                        }
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = password.isNotEmpty() && !isVerifying,
+                onClick = {
+                    scope.launch {
+                        isVerifying = true
+                        val ok = onConfirm(password)
+                        isVerifying = false
+                        if (!ok) wrongPassword = true
+                    }
+                },
+            ) {
+                Text(stringResource(R.string.rot_upgrade_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.rot_upgrade_later))
+            }
+        },
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,8 @@
     <string name="use_biometrics">Use biometrics instead</string>
     <string name="password">Password</string>
     <string name="wrong_password">Incorrect password</string>
+    <string name="rot_upgrade_title">Encryption update</string>
+    <string name="rot_upgrade_body">Tokn now uses a more modern encryption method under the hood. This doesn\'t change how you use the app day to day.\n\nBecause the new method ties your vault\'s key to your password, you need to enter it once to switch over. Afterwards your fingerprint keeps working as usual.</string>
+    <string name="rot_upgrade_confirm">Apply</string>
+    <string name="rot_upgrade_later">Later</string>
 </resources>

--- a/core/data/src/main/java/me/diamondforge/tokn/data/di/DataModule.kt
+++ b/core/data/src/main/java/me/diamondforge/tokn/data/di/DataModule.kt
@@ -25,7 +25,7 @@ import me.diamondforge.tokn.domain.usecase.RecordUsageUseCase
 import me.diamondforge.tokn.domain.usecase.RenameGroupUseCase
 import me.diamondforge.tokn.domain.usecase.ReorderAccountsUseCase
 import me.diamondforge.tokn.domain.usecase.UpdateAccountUseCase
-import me.diamondforge.tokn.security.KeystoreManager
+import me.diamondforge.tokn.security.vault.VaultSession
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 import javax.inject.Singleton
 
@@ -37,10 +37,10 @@ object DataModule {
     @Singleton
     fun provideDatabase(
         @ApplicationContext context: Context,
-        keystoreManager: KeystoreManager,
+        vaultSession: VaultSession,
     ): AppDatabase {
         System.loadLibrary("sqlcipher")
-        val passphrase = keystoreManager.getDatabasePassphrase()
+        val passphrase = vaultSession.requireKey()
         val factory = SupportOpenHelperFactory(passphrase)
         return Room.databaseBuilder(context, AppDatabase::class.java, "otp_database")
             .openHelperFactory(factory)

--- a/core/security/build.gradle.kts
+++ b/core/security/build.gradle.kts
@@ -36,9 +36,11 @@ dependencies {
     implementation(libs.coroutines.android)
     implementation(libs.biometric)
     implementation(libs.hilt.android)
+    implementation(libs.bouncycastle)
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
+    testImplementation(libs.org.json)
 }

--- a/core/security/src/main/java/me/diamondforge/tokn/security/BiometricHelper.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/BiometricHelper.kt
@@ -8,6 +8,7 @@ import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.crypto.Cipher
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -57,5 +58,42 @@ class BiometricHelper @Inject constructor(
             .build()
 
         prompt.authenticate(info)
+    }
+
+    fun authenticateForCrypto(
+        activity: FragmentActivity,
+        title: String,
+        subtitle: String,
+        negativeButton: String,
+        cryptoObject: BiometricPrompt.CryptoObject,
+        onSuccess: (Cipher) -> Unit,
+        onError: (Int, CharSequence) -> Unit,
+        onFailed: () -> Unit,
+    ) {
+        val executor = ContextCompat.getMainExecutor(activity)
+        val callback = object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                val cipher = result.cryptoObject?.cipher
+                if (cipher != null) onSuccess(cipher) else onFailed()
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                onError(errorCode, errString)
+            }
+
+            override fun onAuthenticationFailed() {
+                onFailed()
+            }
+        }
+
+        val prompt = BiometricPrompt(activity, executor, callback)
+        val info = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setAllowedAuthenticators(BIOMETRIC_STRONG)
+            .setNegativeButtonText(negativeButton)
+            .build()
+
+        prompt.authenticate(info, cryptoObject)
     }
 }

--- a/core/security/src/main/java/me/diamondforge/tokn/security/EncryptionManager.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/EncryptionManager.kt
@@ -1,7 +1,10 @@
 package me.diamondforge.tokn.security
 
 import android.util.Base64
+import me.diamondforge.tokn.security.crypto.Argon2KeyDeriver
+import org.json.JSONObject
 import java.security.SecureRandom
+import java.util.Arrays
 import javax.crypto.Cipher
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.GCMParameterSpec
@@ -10,41 +13,72 @@ import javax.crypto.spec.SecretKeySpec
 import javax.inject.Inject
 import javax.inject.Singleton
 
+const val KDF_ARGON2ID = "argon2id"
+const val KDF_PBKDF2 = "pbkdf2"
+
 @Singleton
 class EncryptionManager @Inject constructor() {
 
     fun encrypt(plaintext: ByteArray, password: String): EncryptedPayload {
         val salt = ByteArray(SALT_LENGTH).also { SecureRandom().nextBytes(it) }
-        val key = deriveKey(password, salt)
-        val cipher = Cipher.getInstance(TRANSFORMATION)
-        cipher.init(Cipher.ENCRYPT_MODE, key)
-        val iv = cipher.iv
-        val ciphertext = cipher.doFinal(plaintext)
-        return EncryptedPayload(
-            ciphertext = Base64.encodeToString(ciphertext, Base64.NO_WRAP),
-            iv = Base64.encodeToString(iv, Base64.NO_WRAP),
-            salt = Base64.encodeToString(salt, Base64.NO_WRAP),
-        )
+        val key = deriveArgon2(password, salt)
+        try {
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"))
+            val iv = cipher.iv
+            val ciphertext = cipher.doFinal(plaintext)
+            return EncryptedPayload(
+                ciphertext = Base64.encodeToString(ciphertext, Base64.NO_WRAP),
+                iv = Base64.encodeToString(iv, Base64.NO_WRAP),
+                salt = Base64.encodeToString(salt, Base64.NO_WRAP),
+                kdf = KDF_ARGON2ID,
+                memoryKib = Argon2KeyDeriver.DEFAULT_MEMORY_KIB,
+                iterations = Argon2KeyDeriver.DEFAULT_ITERATIONS,
+                parallelism = Argon2KeyDeriver.DEFAULT_PARALLELISM,
+            )
+        } finally {
+            Arrays.fill(key, 0)
+        }
     }
 
     fun decrypt(payload: EncryptedPayload, password: String): ByteArray {
         val salt = Base64.decode(payload.salt, Base64.NO_WRAP)
         val iv = Base64.decode(payload.iv, Base64.NO_WRAP)
         val ciphertext = Base64.decode(payload.ciphertext, Base64.NO_WRAP)
-        val key = deriveKey(password, salt)
-        val cipher = Cipher.getInstance(TRANSFORMATION)
-        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_LENGTH * 8, iv))
-        return cipher.doFinal(ciphertext)
+        val key = when (payload.kdf) {
+            KDF_PBKDF2 -> derivePbkdf2(password, salt)
+            else -> deriveArgon2(
+                password, salt, payload.memoryKib, payload.iterations, payload.parallelism,
+            )
+        }
+        try {
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(GCM_TAG_LENGTH * 8, iv))
+            return cipher.doFinal(ciphertext)
+        } finally {
+            Arrays.fill(key, 0)
+        }
     }
 
-    private fun deriveKey(password: String, salt: ByteArray): SecretKeySpec {
+    private fun deriveArgon2(
+        password: String,
+        salt: ByteArray,
+        memoryKib: Int = Argon2KeyDeriver.DEFAULT_MEMORY_KIB,
+        iterations: Int = Argon2KeyDeriver.DEFAULT_ITERATIONS,
+        parallelism: Int = Argon2KeyDeriver.DEFAULT_PARALLELISM,
+    ): ByteArray = Argon2KeyDeriver.derive(
+        password = password.toByteArray(Charsets.UTF_8),
+        salt = salt,
+        memoryKib = memoryKib,
+        iterations = iterations,
+        parallelism = parallelism,
+    )
+
+    private fun derivePbkdf2(password: String, salt: ByteArray): ByteArray {
         val factory = SecretKeyFactory.getInstance(PBKDF2_ALGORITHM)
-        val spec = PBEKeySpec(password.toCharArray(), salt, ITERATIONS, KEY_LENGTH_BITS)
+        val spec = PBEKeySpec(password.toCharArray(), salt, PBKDF2_ITERATIONS, KEY_LENGTH_BITS)
         try {
-            val keyBytes = factory.generateSecret(spec).encoded
-            val key = SecretKeySpec(keyBytes, "AES")
-            java.util.Arrays.fill(keyBytes, 0)
-            return key
+            return factory.generateSecret(spec).encoded
         } finally {
             spec.clearPassword()
         }
@@ -55,7 +89,7 @@ class EncryptionManager @Inject constructor() {
         private const val PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA256"
         private const val SALT_LENGTH = 16
         private const val GCM_TAG_LENGTH = 16
-        private const val ITERATIONS = 310_000
+        private const val PBKDF2_ITERATIONS = 310_000
         private const val KEY_LENGTH_BITS = 256
     }
 }
@@ -64,4 +98,32 @@ data class EncryptedPayload(
     val ciphertext: String,
     val iv: String,
     val salt: String,
-)
+    val kdf: String = KDF_ARGON2ID,
+    val memoryKib: Int = Argon2KeyDeriver.DEFAULT_MEMORY_KIB,
+    val iterations: Int = Argon2KeyDeriver.DEFAULT_ITERATIONS,
+    val parallelism: Int = Argon2KeyDeriver.DEFAULT_PARALLELISM,
+) {
+    fun writeTo(obj: JSONObject) {
+        obj.put("ciphertext", ciphertext)
+        obj.put("iv", iv)
+        obj.put("salt", salt)
+        obj.put("kdf", kdf)
+        if (kdf == KDF_ARGON2ID) {
+            obj.put("m", memoryKib)
+            obj.put("t", iterations)
+            obj.put("p", parallelism)
+        }
+    }
+
+    companion object {
+        fun fromJson(obj: JSONObject): EncryptedPayload = EncryptedPayload(
+            ciphertext = obj.getString("ciphertext"),
+            iv = obj.getString("iv"),
+            salt = obj.getString("salt"),
+            kdf = obj.optString("kdf", KDF_PBKDF2),
+            memoryKib = obj.optInt("m", Argon2KeyDeriver.DEFAULT_MEMORY_KIB),
+            iterations = obj.optInt("t", Argon2KeyDeriver.DEFAULT_ITERATIONS),
+            parallelism = obj.optInt("p", Argon2KeyDeriver.DEFAULT_PARALLELISM),
+        )
+    }
+}

--- a/core/security/src/main/java/me/diamondforge/tokn/security/KeystoreManager.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/KeystoreManager.kt
@@ -1,6 +1,7 @@
 package me.diamondforge.tokn.security
 
 import android.content.Context
+import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
@@ -12,6 +13,7 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 import javax.inject.Inject
 import javax.inject.Singleton
+import androidx.core.content.edit
 
 @Singleton
 open class KeystoreManager @Inject constructor(
@@ -33,6 +35,19 @@ open class KeystoreManager @Inject constructor(
         check(committed) { "Failed to persist database passphrase" }
         return passphrase
     }
+
+    @Synchronized
+    open fun readLegacyPassphraseOrNull(): ByteArray? {
+        val stored = prefs.getString(KEY_DB_PASSPHRASE, null) ?: return null
+        return decrypt(stored)
+    }
+
+    @Synchronized
+    open fun clearLegacyPassphrase() {
+        prefs.edit(commit = true) { remove(KEY_DB_PASSPHRASE) }
+    }
+
+    fun generateMasterKey(): ByteArray = generateRandomBytes(32)
 
     open fun encrypt(data: ByteArray): String {
         val key = getOrCreateKey()
@@ -73,6 +88,68 @@ open class KeystoreManager @Inject constructor(
         return (keystore.getEntry(KEY_ALIAS, null) as KeyStore.SecretKeyEntry).secretKey
     }
 
+    open fun hasBiometricKey(): Boolean = keystore.containsAlias(BIOMETRIC_KEY_ALIAS)
+
+    open fun deleteBiometricKey() {
+        if (keystore.containsAlias(BIOMETRIC_KEY_ALIAS)) {
+            keystore.deleteEntry(BIOMETRIC_KEY_ALIAS)
+        }
+    }
+
+    open fun biometricEncryptCipher(): Cipher {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateBiometricKey())
+        return cipher
+    }
+
+    open fun biometricDecryptCipher(wrappedKey: String): Cipher {
+        val combined = Base64.decode(wrappedKey, Base64.NO_WRAP)
+        val iv = combined.copyOfRange(0, GCM_IV_LENGTH)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            keystore.getKey(BIOMETRIC_KEY_ALIAS, null) as SecretKey,
+            GCMParameterSpec(GCM_TAG_LENGTH * 8, iv),
+        )
+        return cipher
+    }
+
+    open fun biometricWrap(authenticatedCipher: Cipher, data: ByteArray): String {
+        val iv = authenticatedCipher.iv
+        val encrypted = authenticatedCipher.doFinal(data)
+        return Base64.encodeToString(iv + encrypted, Base64.NO_WRAP)
+    }
+
+    open fun biometricUnwrap(authenticatedCipher: Cipher, wrappedKey: String): ByteArray {
+        val combined = Base64.decode(wrappedKey, Base64.NO_WRAP)
+        val body = combined.copyOfRange(GCM_IV_LENGTH, combined.size)
+        return authenticatedCipher.doFinal(body)
+    }
+
+    private fun getOrCreateBiometricKey(): SecretKey {
+        if (!keystore.containsAlias(BIOMETRIC_KEY_ALIAS)) {
+            val keyGen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+            val builder = KeyGenParameterSpec.Builder(
+                BIOMETRIC_KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(256)
+                .setUserAuthenticationRequired(true)
+                .setInvalidatedByBiometricEnrollment(true)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                builder.setUserAuthenticationParameters(
+                    0,
+                    KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL,
+                )
+            }
+            keyGen.init(builder.build())
+            keyGen.generateKey()
+        }
+        return keystore.getKey(BIOMETRIC_KEY_ALIAS, null) as SecretKey
+    }
+
     private fun generateRandomBytes(size: Int): ByteArray {
         val bytes = ByteArray(size)
         java.security.SecureRandom().nextBytes(bytes)
@@ -82,6 +159,7 @@ open class KeystoreManager @Inject constructor(
     companion object {
         private const val ANDROID_KEYSTORE = "AndroidKeyStore"
         private const val KEY_ALIAS = "authenticator_db_key"
+        private const val BIOMETRIC_KEY_ALIAS = "vault_biometric_key"
         private const val TRANSFORMATION = "AES/GCM/NoPadding"
         private const val GCM_IV_LENGTH = 12
         private const val GCM_TAG_LENGTH = 16

--- a/core/security/src/main/java/me/diamondforge/tokn/security/crypto/Argon2KeyDeriver.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/crypto/Argon2KeyDeriver.kt
@@ -1,0 +1,32 @@
+package me.diamondforge.tokn.security.crypto
+
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator
+import org.bouncycastle.crypto.params.Argon2Parameters
+
+object Argon2KeyDeriver {
+    const val DEFAULT_MEMORY_KIB = 47_104
+    const val DEFAULT_ITERATIONS = 3
+    const val DEFAULT_PARALLELISM = 2
+    const val KEY_LENGTH = 32
+
+    fun derive(
+        password: ByteArray,
+        salt: ByteArray,
+        memoryKib: Int = DEFAULT_MEMORY_KIB,
+        iterations: Int = DEFAULT_ITERATIONS,
+        parallelism: Int = DEFAULT_PARALLELISM,
+        keyLength: Int = KEY_LENGTH,
+    ): ByteArray {
+        val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+            .withVersion(Argon2Parameters.ARGON2_VERSION_13)
+            .withSalt(salt)
+            .withMemoryAsKB(memoryKib)
+            .withIterations(iterations)
+            .withParallelism(parallelism)
+            .build()
+        val generator = Argon2BytesGenerator().apply { init(params) }
+        val out = ByteArray(keyLength)
+        generator.generateBytes(password, out)
+        return out
+    }
+}

--- a/core/security/src/main/java/me/diamondforge/tokn/security/vault/AesGcm.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/vault/AesGcm.kt
@@ -1,0 +1,28 @@
+package me.diamondforge.tokn.security.vault
+
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+internal object AesGcm {
+    private const val IV_LENGTH = 12
+    private const val TAG_BITS = 128
+    private const val TRANSFORMATION = "AES/GCM/NoPadding"
+
+    fun encrypt(key: ByteArray, plaintext: ByteArray): ByteArray {
+        val iv = ByteArray(IV_LENGTH).also { SecureRandom().nextBytes(it) }
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(TAG_BITS, iv))
+        return iv + cipher.doFinal(plaintext)
+    }
+
+    fun decrypt(key: ByteArray, blob: ByteArray): ByteArray {
+        require(blob.size > IV_LENGTH) { "blob too short" }
+        val iv = blob.copyOfRange(0, IV_LENGTH)
+        val body = blob.copyOfRange(IV_LENGTH, blob.size)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(TAG_BITS, iv))
+        return cipher.doFinal(body)
+    }
+}

--- a/core/security/src/main/java/me/diamondforge/tokn/security/vault/Slot.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/vault/Slot.kt
@@ -1,0 +1,74 @@
+package me.diamondforge.tokn.security.vault
+
+import android.util.Base64
+import org.json.JSONObject
+
+sealed class Slot {
+    abstract val uuid: String
+    abstract fun toJson(): JSONObject
+
+    companion object {
+        const val TYPE_KEYSTORE = "keystore"
+        const val TYPE_PASSWORD = "password"
+
+        fun fromJson(obj: JSONObject): Slot = when (val type = obj.getString("type")) {
+            TYPE_KEYSTORE -> KeystoreSlot.fromJson(obj)
+            TYPE_PASSWORD -> PasswordSlot.fromJson(obj)
+            else -> throw IllegalArgumentException("unknown slot type: $type")
+        }
+    }
+}
+
+class KeystoreSlot(
+    override val uuid: String,
+    val requiresAuth: Boolean,
+    val wrappedKey: String,
+) : Slot() {
+    override fun toJson(): JSONObject = JSONObject().apply {
+        put("type", TYPE_KEYSTORE)
+        put("uuid", uuid)
+        put("auth", requiresAuth)
+        put("key", wrappedKey)
+    }
+
+    companion object {
+        fun fromJson(o: JSONObject) = KeystoreSlot(
+            uuid = o.getString("uuid"),
+            requiresAuth = o.getBoolean("auth"),
+            wrappedKey = o.getString("key"),
+        )
+    }
+}
+
+class PasswordSlot(
+    override val uuid: String,
+    val salt: ByteArray,
+    val memoryKib: Int,
+    val iterations: Int,
+    val parallelism: Int,
+    val wrappedKey: ByteArray,
+) : Slot() {
+    override fun toJson(): JSONObject = JSONObject().apply {
+        put("type", TYPE_PASSWORD)
+        put("uuid", uuid)
+        put("salt", b64(salt))
+        put("m", memoryKib)
+        put("t", iterations)
+        put("p", parallelism)
+        put("key", b64(wrappedKey))
+    }
+
+    companion object {
+        fun fromJson(o: JSONObject) = PasswordSlot(
+            uuid = o.getString("uuid"),
+            salt = d64(o.getString("salt")),
+            memoryKib = o.getInt("m"),
+            iterations = o.getInt("t"),
+            parallelism = o.getInt("p"),
+            wrappedKey = d64(o.getString("key")),
+        )
+    }
+}
+
+private fun b64(bytes: ByteArray): String = Base64.encodeToString(bytes, Base64.NO_WRAP)
+private fun d64(s: String): ByteArray = Base64.decode(s, Base64.NO_WRAP)

--- a/core/security/src/main/java/me/diamondforge/tokn/security/vault/SlotStore.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/vault/SlotStore.kt
@@ -1,0 +1,35 @@
+package me.diamondforge.tokn.security.vault
+
+import android.content.Context
+import androidx.core.content.edit
+import org.json.JSONArray
+
+class SlotStore(context: Context) {
+    private val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    fun isInitialized(): Boolean = prefs.contains(KEY_SLOTS)
+
+    fun load(): MutableList<Slot> {
+        val raw = prefs.getString(KEY_SLOTS, null) ?: return mutableListOf()
+        val arr = JSONArray(raw)
+        return (0 until arr.length())
+            .map { Slot.fromJson(arr.getJSONObject(it)) }
+            .toMutableList()
+    }
+
+    fun save(slots: List<Slot>) {
+        val arr = JSONArray()
+        slots.forEach { arr.put(it.toJson()) }
+        prefs.edit(commit = true) { putString(KEY_SLOTS, arr.toString()) }
+    }
+
+    var legacyPasswordPresent: Boolean
+        get() = prefs.getBoolean(KEY_LEGACY_PW, false)
+        set(value) = prefs.edit(commit = true) { putBoolean(KEY_LEGACY_PW, value) }
+
+    companion object {
+        private const val PREFS = "vault_slots_prefs"
+        private const val KEY_SLOTS = "vault_slots"
+        private const val KEY_LEGACY_PW = "legacy_password_present"
+    }
+}

--- a/core/security/src/main/java/me/diamondforge/tokn/security/vault/VaultManager.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/vault/VaultManager.kt
@@ -1,0 +1,263 @@
+package me.diamondforge.tokn.security.vault
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import me.diamondforge.tokn.security.KeystoreManager
+import me.diamondforge.tokn.security.VaultPasswordManager
+import me.diamondforge.tokn.security.crypto.Argon2KeyDeriver
+import java.security.SecureRandom
+import java.util.Arrays
+import java.util.UUID
+import javax.crypto.AEADBadTagException
+import javax.crypto.Cipher
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+open class VaultManager @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val keystoreManager: KeystoreManager,
+    private val session: VaultSession,
+    private val legacyPassword: VaultPasswordManager,
+) {
+    private val slotStore = SlotStore(context)
+
+    @Synchronized
+    open fun initIfNeeded() {
+        if (slotStore.isInitialized()) return
+
+        val masterKey = keystoreManager.readLegacyPassphraseOrNull()
+            ?: keystoreManager.generateMasterKey()
+        try {
+            slotStore.save(listOf(noAuthSlot(masterKey)))
+            if (legacyPassword.hasPassword()) {
+                slotStore.legacyPasswordPresent = true
+            }
+            keystoreManager.clearLegacyPassphrase()
+        } finally {
+            Arrays.fill(masterKey, 0)
+        }
+    }
+
+    open fun hasPassword(): Boolean = slotStore.load().any { it is PasswordSlot }
+
+    open fun hasPasswordOrLegacy(): Boolean = hasPassword() || slotStore.legacyPasswordPresent
+
+    open fun hasBiometric(): Boolean =
+        slotStore.load().any { it is KeystoreSlot && it.requiresAuth }
+
+    open fun verifyPassword(password: String): Boolean {
+        val slots = slotStore.load()
+        val passwordSlot = slots.firstOrNull { it is PasswordSlot } as? PasswordSlot
+        if (passwordSlot != null) {
+            val masterKey = unwrapPasswordSlot(passwordSlot, password) ?: return false
+            Arrays.fill(masterKey, 0)
+            return true
+        }
+        if (slotStore.legacyPasswordPresent) return legacyPassword.verify(password)
+        return false
+    }
+
+    open fun requiresUnlock(): Boolean {
+        val slots = slotStore.load()
+        return slots.any { it is PasswordSlot } ||
+            slots.any { it is KeystoreSlot && it.requiresAuth } ||
+            slotStore.legacyPasswordPresent
+    }
+
+    open fun canBiometricUnlock(): Boolean = hasBiometric() && keystoreManager.hasBiometricKey()
+
+    open fun canProvisionBiometricFromKeystore(): Boolean =
+        !hasBiometric() && slotStore.load().any { it is KeystoreSlot && !it.requiresAuth }
+
+    open fun needsRootOfTrustUpgrade(): Boolean {
+        val slots = slotStore.load()
+        val hasNoAuth = slots.any { it is KeystoreSlot && !it.requiresAuth }
+        return hasNoAuth && (slots.any { it is PasswordSlot } || slotStore.legacyPasswordPresent)
+    }
+
+    @Synchronized
+    open fun tryAutoUnlock(): Boolean {
+        if (session.isUnlocked) return true
+        val slot = slotStore.load().firstOrNull { it is KeystoreSlot && !it.requiresAuth }
+            as? KeystoreSlot ?: return false
+        val masterKey = keystoreManager.decrypt(slot.wrappedKey)
+        try {
+            session.unlock(masterKey)
+        } finally {
+            Arrays.fill(masterKey, 0)
+        }
+        return true
+    }
+
+    @Synchronized
+    open fun unlockWithPassword(password: String): Boolean {
+        val slots = slotStore.load()
+        val passwordSlot = slots.firstOrNull { it is PasswordSlot } as? PasswordSlot
+
+        if (passwordSlot != null) {
+            val masterKey = unwrapPasswordSlot(passwordSlot, password) ?: return false
+            try {
+                session.unlock(masterKey)
+            } finally {
+                Arrays.fill(masterKey, 0)
+            }
+            return true
+        }
+
+        if (slotStore.legacyPasswordPresent) {
+            return upgradeLegacyPassword(password, slots)
+        }
+
+        return false
+    }
+
+    private fun upgradeLegacyPassword(password: String, slots: List<Slot>): Boolean {
+        if (!legacyPassword.verify(password)) return false
+
+        val noAuth = slots.firstOrNull { it is KeystoreSlot && !it.requiresAuth } as? KeystoreSlot
+            ?: return false
+        val masterKey = keystoreManager.decrypt(noAuth.wrappedKey)
+        try {
+            val upgraded = slots.filterNot { it === noAuth } + passwordSlotFrom(password, masterKey)
+            slotStore.save(upgraded)
+            slotStore.legacyPasswordPresent = false
+            legacyPassword.clear()
+            session.unlock(masterKey)
+        } finally {
+            Arrays.fill(masterKey, 0)
+        }
+        return true
+    }
+
+    open fun biometricEncryptCipher(): Cipher = keystoreManager.biometricEncryptCipher()
+
+    open fun biometricDecryptCipher(): Cipher? {
+        val slot = biometricSlot() ?: return null
+        return runCatching { keystoreManager.biometricDecryptCipher(slot.wrappedKey) }.getOrNull()
+    }
+
+    @Synchronized
+    open fun provisionAndUnlockBiometric(authenticatedEncryptCipher: Cipher): Boolean {
+        val noAuth = slotStore.load().firstOrNull { it is KeystoreSlot && !it.requiresAuth }
+            as? KeystoreSlot ?: return false
+        val masterKey = keystoreManager.decrypt(noAuth.wrappedKey)
+        try {
+            val wrapped = keystoreManager.biometricWrap(authenticatedEncryptCipher, masterKey)
+            val slots = slotStore.load().filterNot { it is KeystoreSlot && it.requiresAuth } +
+                KeystoreSlot(newUuid(), requiresAuth = true, wrappedKey = wrapped)
+            slotStore.save(slots)
+            session.unlock(masterKey)
+        } finally {
+            Arrays.fill(masterKey, 0)
+        }
+        return true
+    }
+
+    @Synchronized
+    open fun finishBiometricUnlock(authenticatedCipher: Cipher): Boolean {
+        val slot = biometricSlot() ?: return false
+        val masterKey = runCatching {
+            keystoreManager.biometricUnwrap(authenticatedCipher, slot.wrappedKey)
+        }.getOrNull() ?: return false
+        try {
+            session.unlock(masterKey)
+        } finally {
+            Arrays.fill(masterKey, 0)
+        }
+        return true
+    }
+
+    @Synchronized
+    open fun setPassword(password: String) {
+        val masterKey = session.requireKey()
+        try {
+            val slots = slotStore.load()
+                .filterNot { it is KeystoreSlot && !it.requiresAuth }
+                .filterNot { it is PasswordSlot }
+            slotStore.save(slots + passwordSlotFrom(password, masterKey))
+            slotStore.legacyPasswordPresent = false
+            legacyPassword.clear()
+        } finally {
+            Arrays.fill(masterKey, 0)
+        }
+    }
+
+    @Synchronized
+    open fun removePassword() {
+        val masterKey = session.requireKey()
+        try {
+            slotStore.save(listOf(noAuthSlot(masterKey)))
+            slotStore.legacyPasswordPresent = false
+            legacyPassword.clear()
+            keystoreManager.deleteBiometricKey()
+        } finally {
+            Arrays.fill(masterKey, 0)
+        }
+    }
+
+    @Synchronized
+    open fun enableBiometric(authenticatedCipher: Cipher) {
+        val masterKey = session.requireKey()
+        try {
+            val wrapped = keystoreManager.biometricWrap(authenticatedCipher, masterKey)
+            val slots = slotStore.load().filterNot { it is KeystoreSlot && it.requiresAuth }
+            slotStore.save(slots + KeystoreSlot(newUuid(), requiresAuth = true, wrappedKey = wrapped))
+        } finally {
+            Arrays.fill(masterKey, 0)
+        }
+    }
+
+    @Synchronized
+    open fun disableBiometric() {
+        val slots = slotStore.load().filterNot { it is KeystoreSlot && it.requiresAuth }
+        slotStore.save(slots)
+        keystoreManager.deleteBiometricKey()
+    }
+
+    private fun biometricSlot(): KeystoreSlot? =
+        slotStore.load().firstOrNull { it is KeystoreSlot && it.requiresAuth } as? KeystoreSlot
+
+    private fun noAuthSlot(masterKey: ByteArray): KeystoreSlot =
+        KeystoreSlot(newUuid(), requiresAuth = false, wrappedKey = keystoreManager.encrypt(masterKey))
+
+    private fun unwrapPasswordSlot(slot: PasswordSlot, password: String): ByteArray? {
+        val kek = Argon2KeyDeriver.derive(
+            password = password.toByteArray(Charsets.UTF_8),
+            salt = slot.salt,
+            memoryKib = slot.memoryKib,
+            iterations = slot.iterations,
+            parallelism = slot.parallelism,
+        )
+        return try {
+            AesGcm.decrypt(kek, slot.wrappedKey)
+        } catch (_: AEADBadTagException) {
+            null
+        } finally {
+            Arrays.fill(kek, 0)
+        }
+    }
+
+    private fun passwordSlotFrom(password: String, masterKey: ByteArray): PasswordSlot {
+        val salt = ByteArray(SALT_LENGTH).also { SecureRandom().nextBytes(it) }
+        val kek = Argon2KeyDeriver.derive(password.toByteArray(Charsets.UTF_8), salt)
+        try {
+            return PasswordSlot(
+                uuid = newUuid(),
+                salt = salt,
+                memoryKib = Argon2KeyDeriver.DEFAULT_MEMORY_KIB,
+                iterations = Argon2KeyDeriver.DEFAULT_ITERATIONS,
+                parallelism = Argon2KeyDeriver.DEFAULT_PARALLELISM,
+                wrappedKey = AesGcm.encrypt(kek, masterKey),
+            )
+        } finally {
+            Arrays.fill(kek, 0)
+        }
+    }
+
+    private fun newUuid(): String = UUID.randomUUID().toString()
+
+    companion object {
+        private const val SALT_LENGTH = 16
+    }
+}

--- a/core/security/src/main/java/me/diamondforge/tokn/security/vault/VaultSession.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/vault/VaultSession.kt
@@ -1,0 +1,39 @@
+package me.diamondforge.tokn.security.vault
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.Arrays
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class VaultState { LOCKED, UNLOCKED }
+
+@Singleton
+class VaultSession @Inject constructor() {
+
+    @Volatile
+    private var masterKey: ByteArray? = null
+
+    private val _state = MutableStateFlow(VaultState.LOCKED)
+    val state: StateFlow<VaultState> = _state.asStateFlow()
+
+    val isUnlocked: Boolean get() = masterKey != null
+
+    @Synchronized
+    fun unlock(key: ByteArray) {
+        masterKey?.let { Arrays.fill(it, 0) }
+        masterKey = key.copyOf()
+        _state.value = VaultState.UNLOCKED
+    }
+
+    @Synchronized
+    fun lock() {
+        masterKey?.let { Arrays.fill(it, 0) }
+        masterKey = null
+        _state.value = VaultState.LOCKED
+    }
+
+    fun requireKey(): ByteArray =
+        (masterKey ?: error("Vault is locked")).copyOf()
+}

--- a/core/security/src/test/java/me/diamondforge/tokn/security/EncryptionManagerLegacyTest.kt
+++ b/core/security/src/test/java/me/diamondforge/tokn/security/EncryptionManagerLegacyTest.kt
@@ -1,0 +1,76 @@
+package me.diamondforge.tokn.security
+
+import android.util.Base64
+import org.json.JSONObject
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class EncryptionManagerLegacyTest {
+
+    private val manager = EncryptionManager()
+
+    @Test
+    fun `decrypts a legacy PBKDF2 payload`() {
+        val password = "correct horse battery staple"
+        val plaintext = "legacy vault contents 🔐".toByteArray()
+        val payload = makeLegacyPayload(plaintext, password)
+
+        assertArrayEquals(plaintext, manager.decrypt(payload, password))
+    }
+
+    @Test
+    fun `old wrapper json without kdf is read as PBKDF2 and decrypts`() {
+        val password = "pw"
+        val plaintext = "data".toByteArray()
+        val legacy = makeLegacyPayload(plaintext, password)
+
+        // Emulate an on-disk backup wrapper from the previous version: only the
+        // three original fields, no kdf metadata.
+        val wrapper = JSONObject().apply {
+            put("ciphertext", legacy.ciphertext)
+            put("iv", legacy.iv)
+            put("salt", legacy.salt)
+        }
+
+        val parsed = EncryptedPayload.fromJson(wrapper)
+        assertEquals(KDF_PBKDF2, parsed.kdf)
+        assertEquals("data", manager.decrypt(parsed, password).toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `new argon2 payload survives a writeTo and fromJson round trip`() {
+        val payload = manager.encrypt("hello".toByteArray(), "pw")
+        val obj = JSONObject().apply { payload.writeTo(this) }
+
+        val parsed = EncryptedPayload.fromJson(obj)
+        assertEquals(KDF_ARGON2ID, parsed.kdf)
+        assertEquals("hello", manager.decrypt(parsed, "pw").toString(Charsets.UTF_8))
+    }
+
+    private fun makeLegacyPayload(plaintext: ByteArray, password: String): EncryptedPayload {
+        val salt = ByteArray(16) { (it + 3).toByte() }
+        val spec = PBEKeySpec(password.toCharArray(), salt, 310_000, 256)
+        val keyBytes = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+            .generateSecret(spec).encoded
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(keyBytes, "AES"))
+        val iv = cipher.iv
+        val ciphertext = cipher.doFinal(plaintext)
+        return EncryptedPayload(
+            ciphertext = Base64.encodeToString(ciphertext, Base64.NO_WRAP),
+            iv = Base64.encodeToString(iv, Base64.NO_WRAP),
+            salt = Base64.encodeToString(salt, Base64.NO_WRAP),
+            kdf = KDF_PBKDF2,
+        )
+    }
+}

--- a/core/security/src/test/java/me/diamondforge/tokn/security/vault/VaultManagerTest.kt
+++ b/core/security/src/test/java/me/diamondforge/tokn/security/vault/VaultManagerTest.kt
@@ -1,0 +1,196 @@
+package me.diamondforge.tokn.security.vault
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import me.diamondforge.tokn.security.KeystoreManager
+import me.diamondforge.tokn.security.VaultPasswordManager
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Base64
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class VaultManagerTest {
+
+    private lateinit var context: Context
+    private lateinit var fakeKeystore: FakeKeystoreManager
+    private lateinit var session: VaultSession
+    private lateinit var legacyPassword: VaultPasswordManager
+    private lateinit var manager: VaultManager
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+        fakeKeystore = FakeKeystoreManager(context)
+        session = VaultSession()
+        legacyPassword = VaultPasswordManager(fakeKeystore, context)
+        manager = VaultManager(context, fakeKeystore, session, legacyPassword)
+    }
+
+    @Test
+    fun `migration without password creates a no-auth slot and auto-unlocks to the same key`() {
+        val masterKey = fixedKey(7)
+        fakeKeystore.legacyPassphrase = masterKey.copyOf()
+
+        manager.initIfNeeded()
+
+        assertFalse(manager.requiresUnlock())
+        assertTrue(manager.tryAutoUnlock())
+        assertArrayEquals(masterKey, session.requireKey())
+    }
+
+    @Test
+    fun `fresh install generates a master key and can auto-unlock`() {
+        fakeKeystore.legacyPassphrase = null
+
+        manager.initIfNeeded()
+
+        assertFalse(manager.requiresUnlock())
+        assertTrue(manager.tryAutoUnlock())
+        // 32-byte AES key present
+        assertTrue(session.requireKey().size == 32)
+    }
+
+    @Test
+    fun `setting a password removes the no-auth slot but keeps the same master key`() {
+        val masterKey = fixedKey(11)
+        fakeKeystore.legacyPassphrase = masterKey.copyOf()
+        manager.initIfNeeded()
+        manager.tryAutoUnlock()
+
+        manager.setPassword("hunter2")
+
+        assertTrue(manager.hasPassword())
+        assertTrue(manager.requiresUnlock())
+
+        // Re-unlock from a cold session via the Argon2 password slot.
+        session.lock()
+        assertFalse(manager.unlockWithPassword("wrong"))
+        assertTrue(manager.unlockWithPassword("hunter2"))
+        assertArrayEquals(masterKey, session.requireKey())
+    }
+
+    @Test
+    fun `removing the password restores transparent auto-unlock with the same key`() {
+        val masterKey = fixedKey(13)
+        fakeKeystore.legacyPassphrase = masterKey.copyOf()
+        manager.initIfNeeded()
+        manager.tryAutoUnlock()
+        manager.setPassword("pw")
+
+        manager.removePassword()
+
+        assertFalse(manager.hasPassword())
+        assertFalse(manager.requiresUnlock())
+        session.lock()
+        assertTrue(manager.tryAutoUnlock())
+        assertArrayEquals(masterKey, session.requireKey())
+    }
+
+    @Test
+    fun `legacy PBKDF2 password is lazily upgraded to an Argon2 slot without losing data`() {
+        val masterKey = fixedKey(23)
+        fakeKeystore.legacyPassphrase = masterKey.copyOf()
+        // Simulate the pre-slot world: an old PBKDF2 vault password exists.
+        legacyPassword.setup("oldpw")
+
+        manager.initIfNeeded()
+
+        // Behaves like the old overlay until the user types the password.
+        assertTrue(manager.requiresUnlock())
+        assertTrue(manager.legacyFlagForTest())
+
+        assertFalse(manager.unlockWithPassword("nope"))
+        assertTrue(manager.unlockWithPassword("oldpw"))
+        assertArrayEquals(masterKey, session.requireKey())
+
+        // After the upgrade: a real Argon2 slot, no no-auth slot, legacy cleared.
+        assertTrue(manager.hasPassword())
+        assertFalse(manager.legacyFlagForTest())
+        assertFalse(legacyPassword.hasPassword())
+
+        // Subsequent cold unlocks go through the Argon2 slot.
+        session.lock()
+        assertTrue(manager.unlockWithPassword("oldpw"))
+        assertArrayEquals(masterKey, session.requireKey())
+    }
+
+    @Test
+    fun `needsRootOfTrustUpgrade is true after legacy migration and false once password confirmed`() {
+        fakeKeystore.legacyPassphrase = fixedKey(41)
+        legacyPassword.setup("pw")
+        manager.initIfNeeded()
+
+        assertTrue(manager.needsRootOfTrustUpgrade())
+
+        assertTrue(manager.unlockWithPassword("pw"))
+        assertFalse(manager.needsRootOfTrustUpgrade())
+    }
+
+    @Test
+    fun `needsRootOfTrustUpgrade is false for password-only and no-password users`() {
+        fakeKeystore.legacyPassphrase = fixedKey(43)
+        manager.initIfNeeded() // no-password migration: no-auth slot, but no password
+        assertFalse(manager.needsRootOfTrustUpgrade())
+
+        manager.tryAutoUnlock()
+        manager.setPassword("pw") // proper Argon2 password, no-auth slot removed
+        assertFalse(manager.needsRootOfTrustUpgrade())
+    }
+
+    @Test
+    fun `initIfNeeded is idempotent`() {
+        fakeKeystore.legacyPassphrase = fixedKey(31)
+        manager.initIfNeeded()
+        manager.tryAutoUnlock()
+        val key = session.requireKey()
+
+        manager.initIfNeeded() // must not regenerate or overwrite
+
+        session.lock()
+        manager.tryAutoUnlock()
+        assertArrayEquals(key, session.requireKey())
+    }
+
+    private fun clearPrefs() {
+        listOf("vault_slots_prefs", "vault_password_prefs").forEach {
+            context.getSharedPreferences(it, Context.MODE_PRIVATE).edit().clear().commit()
+        }
+    }
+
+    private fun fixedKey(seed: Int) = ByteArray(32) { (it + seed).toByte() }
+
+    private class FakeKeystoreManager(context: Context) : KeystoreManager(context) {
+        var legacyPassphrase: ByteArray? = null
+
+        override fun getDatabasePassphrase(): ByteArray =
+            legacyPassphrase?.copyOf() ?: ByteArray(32) { 1 }.also { legacyPassphrase = it.copyOf() }
+
+        override fun readLegacyPassphraseOrNull(): ByteArray? = legacyPassphrase?.copyOf()
+
+        override fun clearLegacyPassphrase() {
+            legacyPassphrase = null
+        }
+
+        // No biometric slot in these tests; keep off the real AndroidKeyStore.
+        override fun hasBiometricKey(): Boolean = false
+        override fun deleteBiometricKey() = Unit
+
+        override fun encrypt(data: ByteArray): String =
+            "kc:" + Base64.getEncoder().encodeToString(data)
+
+        override fun decrypt(encoded: String): ByteArray {
+            require(encoded.startsWith("kc:")) { "unexpected envelope: $encoded" }
+            return Base64.getDecoder().decode(encoded.removePrefix("kc:"))
+        }
+    }
+}
+
+private fun VaultManager.legacyFlagForTest(): Boolean = requiresUnlock() && !hasPassword()

--- a/feature/backup/src/main/java/me/diamondforge/tokn/backup/EncryptedBackupManager.kt
+++ b/feature/backup/src/main/java/me/diamondforge/tokn/backup/EncryptedBackupManager.kt
@@ -14,11 +14,7 @@ class EncryptedBackupManager @Inject constructor(
 ) {
     fun exportToUri(context: Context, uri: Uri, plainJson: String, password: String) {
         val payload = encryptionManager.encrypt(plainJson.toByteArray(Charsets.UTF_8), password)
-        val wrapper = JSONObject().apply {
-            put("ciphertext", payload.ciphertext)
-            put("iv", payload.iv)
-            put("salt", payload.salt)
-        }
+        val wrapper = JSONObject().apply { payload.writeTo(this) }
         context.contentResolver.openOutputStream(uri)?.use { stream ->
             stream.write(wrapper.toString().toByteArray(Charsets.UTF_8))
         } ?: error("Cannot open output stream")
@@ -33,11 +29,7 @@ class EncryptedBackupManager @Inject constructor(
 
     fun decryptBytes(raw: ByteArray, password: String): String {
         val wrapper = JSONObject(raw.toString(Charsets.UTF_8))
-        val payload = EncryptedPayload(
-            ciphertext = wrapper.getString("ciphertext"),
-            iv = wrapper.getString("iv"),
-            salt = wrapper.getString("salt"),
-        )
+        val payload = EncryptedPayload.fromJson(wrapper)
         return encryptionManager.decrypt(payload, password).toString(Charsets.UTF_8)
     }
 }

--- a/feature/onboarding/src/main/java/me/diamondforge/tokn/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/me/diamondforge/tokn/onboarding/OnboardingScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
@@ -49,6 +50,7 @@ private val SLIDES = listOf(Slide.Welcome, Slide.SecurityPicker, Slide.SecurityS
 @Composable
 fun OnboardingScreen(
     onFinished: () -> Unit,
+    onSetupBiometric: suspend () -> Boolean = { true },
     viewModel: OnboardingViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -57,6 +59,7 @@ fun OnboardingScreen(
 
     val pagerState = rememberPagerState(pageCount = { SLIDES.size })
     val pickMethodMsg = stringResource(R.string.onboarding_security_pick_method)
+    val biometricRequiredMsg = stringResource(R.string.onboarding_biometric_required)
 
     // A successful Welcome-slide import is the user's signal that they're done
     // with this step; pause briefly so the "Imported N accounts" feedback can
@@ -69,47 +72,16 @@ fun OnboardingScreen(
     }
 
     Scaffold(
-        snackbarHost = { SnackbarHost(snackbar) },
-        containerColor = MaterialTheme.colorScheme.background,
-    ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
-        ) {
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                userScrollEnabled = false,
-            ) { page ->
-                when (SLIDES[page]) {
-                    Slide.Welcome -> WelcomeSlide(
-                        state = state,
-                        onImport = viewModel::importBackup,
-                        onCancelPendingImport = viewModel::cancelPendingImport,
-                        onSuppressLock = viewModel::suppressLock,
-                        onClearImportFeedback = viewModel::clearImportFeedback,
-                    )
-
-                    Slide.SecurityPicker -> SecurityPickerSlide(
-                        selected = state.cryptType,
-                        biometricAvailable = state.biometricAvailable,
-                        onSelect = viewModel::setCryptType,
-                    )
-
-                    Slide.SecuritySetup -> SecuritySetupSlide(
-                        password = state.password,
-                        passwordConfirm = state.passwordConfirm,
-                        onPasswordChange = viewModel::setPassword,
-                        onPasswordConfirmChange = viewModel::setPasswordConfirm,
-                    )
-
-                    Slide.Done -> DoneSlide()
-                }
+        snackbarHost = {
+            SnackbarHost(snackbar) { data ->
+                Snackbar(
+                    snackbarData = data,
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                )
             }
-
+        },
+        bottomBar = {
             // Visible (effective) slide count for the indicator: SecuritySetup is hidden when NONE.
             val visibleCount =
                 if (state.cryptType == CryptType.NONE) SLIDES.size - 1 else SLIDES.size
@@ -131,20 +103,67 @@ fun OnboardingScreen(
                 },
                 onNext = {
                     val current = SLIDES[pagerState.currentPage]
-                    if (current == Slide.SecurityPicker && state.cryptType == null) {
-                        scope.launch { snackbar.showSnackbar(pickMethodMsg) }
-                        return@PagerControls
-                    }
-                    if (current == Slide.Done) {
-                        viewModel.finish(onFinished)
-                    } else {
-                        scope.launch {
-                            val target = nextPage(pagerState.currentPage, state.cryptType)
-                            pagerState.animateScrollToPage(target)
+                    when {
+                        current == Slide.SecurityPicker && state.cryptType == null -> {
+                            scope.launch { snackbar.showSnackbar(pickMethodMsg) }
+                        }
+
+                        current == Slide.SecurityPicker && state.cryptType == CryptType.BIOMETRIC -> {
+                            scope.launch {
+                                if (onSetupBiometric()) {
+                                    pagerState.animateScrollToPage(
+                                        nextPage(pagerState.currentPage, state.cryptType),
+                                    )
+                                } else {
+                                    snackbar.showSnackbar(biometricRequiredMsg)
+                                }
+                            }
+                        }
+
+                        current == Slide.Done -> viewModel.finish(onFinished)
+
+                        else -> scope.launch {
+                            pagerState.animateScrollToPage(
+                                nextPage(pagerState.currentPage, state.cryptType),
+                            )
                         }
                     }
                 },
             )
+        },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { padding ->
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            userScrollEnabled = false,
+        ) { page ->
+            when (SLIDES[page]) {
+                Slide.Welcome -> WelcomeSlide(
+                    state = state,
+                    onImport = viewModel::importBackup,
+                    onCancelPendingImport = viewModel::cancelPendingImport,
+                    onSuppressLock = viewModel::suppressLock,
+                    onClearImportFeedback = viewModel::clearImportFeedback,
+                )
+
+                Slide.SecurityPicker -> SecurityPickerSlide(
+                    selected = state.cryptType,
+                    biometricAvailable = state.biometricAvailable,
+                    onSelect = viewModel::setCryptType,
+                )
+
+                Slide.SecuritySetup -> SecuritySetupSlide(
+                    password = state.password,
+                    passwordConfirm = state.passwordConfirm,
+                    onPasswordChange = viewModel::setPassword,
+                    onPasswordConfirmChange = viewModel::setPasswordConfirm,
+                )
+
+                Slide.Done -> DoneSlide()
+            }
         }
     }
 }

--- a/feature/onboarding/src/main/java/me/diamondforge/tokn/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/me/diamondforge/tokn/onboarding/OnboardingViewModel.kt
@@ -155,11 +155,14 @@ class OnboardingViewModel @Inject constructor(
                 if (type != CryptType.NONE) {
                     vaultManager.setPassword(state.password)
                 }
+                // edge case, user want  a other method
+                if (type != CryptType.BIOMETRIC) {
+                    vaultManager.disableBiometric()
+                }
                 preferences.setEncryptionEnabled(type != CryptType.NONE)
                 preferences.setBiometricEnabled(type == CryptType.BIOMETRIC)
                 preferences.setOnboardingDone(true)
             }
-            // Avoid the lock screen flashing while transitioning into the app
             lockManager.suppressNextForeground()
             lockManager.unlock()
             _uiState.update { it.copy(isFinishing = false) }

--- a/feature/onboarding/src/main/java/me/diamondforge/tokn/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/me/diamondforge/tokn/onboarding/OnboardingViewModel.kt
@@ -19,7 +19,7 @@ import me.diamondforge.tokn.importer.ImportOutcome
 import me.diamondforge.tokn.importer.ImporterRegistry
 import me.diamondforge.tokn.security.BiometricHelper
 import me.diamondforge.tokn.security.LockManager
-import me.diamondforge.tokn.security.VaultPasswordManager
+import me.diamondforge.tokn.security.vault.VaultManager
 import javax.inject.Inject
 
 enum class CryptType { NONE, PASSWORD, BIOMETRIC }
@@ -43,7 +43,7 @@ data class OnboardingUiState(
 class OnboardingViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val preferences: UserPreferencesRepository,
-    private val vaultPasswordManager: VaultPasswordManager,
+    private val vaultManager: VaultManager,
     private val addAccountUseCase: AddAccountUseCase,
     private val lockManager: LockManager,
     private val importerRegistry: ImporterRegistry,
@@ -153,7 +153,7 @@ class OnboardingViewModel @Inject constructor(
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
                 if (type != CryptType.NONE) {
-                    vaultPasswordManager.setup(state.password)
+                    vaultManager.setPassword(state.password)
                 }
                 preferences.setEncryptionEnabled(type != CryptType.NONE)
                 preferences.setBiometricEnabled(type == CryptType.BIOMETRIC)

--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -36,4 +36,5 @@
 
     <string name="onboarding_next">Next</string>
     <string name="onboarding_previous">Previous</string>
+    <string name="onboarding_biometric_required">Fingerprint setup is required to continue.</string>
 </resources>

--- a/feature/settings/src/main/java/me/diamondforge/tokn/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/me/diamondforge/tokn/settings/SettingsViewModel.kt
@@ -11,18 +11,19 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import me.diamondforge.tokn.data.preferences.AppPreferencesRepository
 import me.diamondforge.tokn.data.preferences.ThemeMode
 import me.diamondforge.tokn.data.preferences.UserPreferencesRepository
 import me.diamondforge.tokn.domain.model.TapBehavior
-import me.diamondforge.tokn.security.VaultPasswordManager
+import me.diamondforge.tokn.security.vault.VaultManager
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val preferences: UserPreferencesRepository,
     private val appPreferences: AppPreferencesRepository,
-    private val vaultPasswordManager: VaultPasswordManager,
+    private val vaultManager: VaultManager,
 ) : ViewModel() {
 
     private val _passwordError = MutableStateFlow(false)
@@ -62,7 +63,13 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun setBiometricEnabled(enabled: Boolean) {
-        viewModelScope.launch { preferences.setBiometricEnabled(enabled) }
+        viewModelScope.launch {
+            preferences.setBiometricEnabled(enabled)
+            // Enabling provisions the slot via a prompt in MainActivity (needs the Activity).
+            if (!enabled) {
+                withContext(Dispatchers.IO) { vaultManager.disableBiometric() }
+            }
+        }
     }
 
     fun setScreenshotsEnabled(enabled: Boolean) {
@@ -87,16 +94,17 @@ class SettingsViewModel @Inject constructor(
 
     fun setupEncryption(password: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            vaultPasswordManager.setup(password)
+            vaultManager.setPassword(password)
             preferences.setEncryptionEnabled(true)
         }
     }
 
     fun disableEncryption(password: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            if (vaultPasswordManager.verify(password)) {
-                vaultPasswordManager.clear()
+            if (vaultManager.verifyPassword(password)) {
+                vaultManager.removePassword()
                 preferences.setEncryptionEnabled(false)
+                preferences.setBiometricEnabled(false)
             } else {
                 _passwordError.update { true }
             }

--- a/feature/sync/src/main/java/me/diamondforge/tokn/sync/ui/ReceiveViewModel.kt
+++ b/feature/sync/src/main/java/me/diamondforge/tokn/sync/ui/ReceiveViewModel.kt
@@ -193,11 +193,7 @@ class ReceiveViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 val wrapper = JSONObject(String(payload, Charsets.UTF_8))
-                val encrypted = EncryptedPayload(
-                    ciphertext = wrapper.getString("ciphertext"),
-                    iv = wrapper.getString("iv"),
-                    salt = wrapper.getString("salt"),
-                )
+                val encrypted = EncryptedPayload.fromJson(wrapper)
                 val plain = encryptionManager.decrypt(encrypted, passphrase)
                 val decoded = if (Gzip.looksGzipped(plain)) Gzip.decompress(plain) else plain
                 val accounts = SyncPayload.deserialize(String(decoded, Charsets.UTF_8))

--- a/feature/sync/src/main/java/me/diamondforge/tokn/sync/ui/SendViewModel.kt
+++ b/feature/sync/src/main/java/me/diamondforge/tokn/sync/ui/SendViewModel.kt
@@ -241,9 +241,7 @@ class SendViewModel @Inject constructor(
                     val compressed = Gzip.compress(plain.toByteArray(Charsets.UTF_8))
                     val payload = encryptionManager.encrypt(compressed, passphrase)
                     val wrapper = JSONObject().apply {
-                        put("ciphertext", payload.ciphertext)
-                        put("iv", payload.iv)
-                        put("salt", payload.salt)
+                        payload.writeTo(this)
                         put("version", SyncPayload.VERSION)
                         put("protocol", SyncProtocol.VERSION)
                         put("app", appInfo.versionName)


### PR DESCRIPTION
before: 
The sqlite db was encrypted with a random passphrase that lived in the android keystore without user auth. The vault password was basically just a screen lock on top; it didn't actually protect the data at rest. On an rooted device the db key was always recoverable. backups/sync used pbkdf2.

now:  
The db is encrypted with a random master key that's wrapped in slots
- password slot -> key derived with argon2id
- biometric slot -> wrapped by a keystore key bound to user auth (real cryptoobject unlock, not just a prompt)
- no-auth keystore slot -> only exists when no password is set

migration: Fully data-safe. Existing installs keep their exact db key. Biometric users just keep using their finger. The biometric slot is provisioned on the first unlock from one fingerprint prompt, no password needed. a one-time "encryption update" prompt lets them confirm their password once to finish the move to full root-of-trust. password always works as a fallback, so no lockout.

backup/sync: new payloads use argon2id, old pbkdf2 backups are still readable.