### PR TITLE
Fix me.diamondforge.tokn.security.KeystoreManager.keystore_delegate$lambda$0(KeystoreManager.kt:23)

### DIFF
--- a/core/security/src/main/java/me/diamondforge/tokn/security/KeystoreManager.kt
+++ b/core/security/src/main/java/me/diamondforge/tokn/security/KeystoreManager.kt
@@ -19,9 +19,9 @@ import javax.inject.Singleton
 open class KeystoreManager @Inject constructor(
     @param:ApplicationContext private val context: Context,
 ) {
-    private val keystore: KeyStore by lazy {
-        KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
-    }
+private val keystore: KeyStore by lazy {
+    KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(ByteArrayInputStream(byteArrayOf())) }
+}
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
     @Synchronized


### PR DESCRIPTION
# Fix: `me.diamondforge.tokn.security.KeystoreManager.keystore_delegate$lambda$0(KeystoreManager.kt:23)`

## Explanation

The original method creates an instance of the Android Keystore using the `KeyStore.getInstance(ANDROID_KEYSTORE)` method and attempts to load it with a null input stream. However, the Android Keystore requires a valid input stream to be loaded, which is not possible in this case. Therefore, the err

---

## Modified Method

| Property | Value |
|---|---|
| Method | `me.diamondforge.tokn.security.KeystoreManager.keystore_delegate$lambda$0(KeystoreManager.kt:23)` |
| Class | `me.diamondforge.tokn.security.KeystoreManager.keystore_delegate$lambda$0(KeystoreManager.kt:23)` |
| File | `/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/me.diamondforge.tokn_19.apk/core/security/src/main/java/me/diamondforge/tokn/security/KeystoreManager.kt` |
| Status | `SUCCESS` |

---

## Changed File

```text
/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/me.diamondforge.tokn_19.apk/core/security/src/main/java/me/diamondforge/tokn/security/KeystoreManager.kt
```

---


## Validation Checklist

- [x] Method replaced in source file
- [x] Repository updated
- [x] Commit generated
- [ ] Manual review required
- [ ] CI validation pending

---

Repair Pipeline